### PR TITLE
Negotiate Accept header properly.

### DIFF
--- a/src/Airship/Decision.hs
+++ b/src/Airship/Decision.hs
@@ -28,7 +28,6 @@ import           Data.Time.Clock (UTCTime)
 import           Network.HTTP.Media
 import qualified Network.HTTP.Types as HTTP
 import           Network.Wai (requestMethod, requestHeaders, pathInfo)
-import           Debug.Trace
 
 ------------------------------------------------------------------------------
 -- HTTP Headers
@@ -125,7 +124,7 @@ b13 r@Resource{..} = do
         else lift $ halt HTTP.status503
 
 b12 r@Resource{..} = do
-    -- known methodhas
+    -- known method
     req <- lift request
     let knownMethods = [ HTTP.methodGet
                        , HTTP.methodPost
@@ -199,7 +198,6 @@ b03 r@Resource{..} = do
 ------------------------------------------------------------------------------
 -- C column
 ------------------------------------------------------------------------------
-
 
 c04 r@Resource{..} = do
     req <- lift request

--- a/src/Airship/Resource.hs
+++ b/src/Airship/Resource.hs
@@ -12,8 +12,7 @@ module Airship.Resource
     , singletonContentType
     ) where
 
-import Airship.Types (ContentType, Handler, Response(..), ResponseBody(..),
-                      finishWith)
+import Airship.Types (Handler, Response(..), ResponseBody(..), finishWith)
 
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
@@ -22,6 +21,7 @@ import Blaze.ByteString.Builder.ByteString (fromByteString)
 import Blaze.ByteString.Builder.Html.Utf8 (fromHtmlEscapedText)
 
 import Network.HTTP.Types
+import Network.HTTP.Media (MediaType)
 
 -- Credit for this idea goes to Richard Wallace (purefn) on Webcrank.
 -- This creates an enumeration for the four possibilities of two binary
@@ -37,7 +37,7 @@ data PostResponse s m
 data Resource s m =
     Resource { allowMissingPost         :: Handler s m Bool
              , allowedMethods           :: Handler s m [Method]
-             , contentTypesProvided     :: Handler s m [(ContentType, ResponseBody m)]
+             , contentTypesProvided     :: Handler s m [(MediaType, ResponseBody m)]
              , createPath               :: Handler s m (Maybe Text)
              , deleteCompleted          :: Handler s m Bool
              , deleteResource           :: Handler s m Bool
@@ -97,5 +97,5 @@ defaultResource = Resource { allowMissingPost       = return False
 helloWorld :: ResponseBody m
 helloWorld = ResponseBuilder (fromByteString "Hello, world!")
 
-singletonContentType :: ContentType -> Text -> [(ContentType, ResponseBody m)]
+singletonContentType :: MediaType -> Text -> [(MediaType, ResponseBody m)]
 singletonContentType ct tex = [(ct, ResponseBuilder (fromHtmlEscapedText tex))]

--- a/src/Airship/Types.hs
+++ b/src/Airship/Types.hs
@@ -9,8 +9,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Airship.Types
-    ( ContentType
-    , ETag(..)
+    ( ETag(..)
     , Webmachine
     , Handler
     , Response(..)
@@ -35,7 +34,6 @@ import Blaze.ByteString.Builder (Builder)
 import Blaze.ByteString.Builder.ByteString (fromByteString)
 
 import Data.ByteString.Char8
-import Data.CaseInsensitive (CI)
 import Data.Time.Clock (UTCTime)
 
 import Control.Applicative (Applicative, (<$>))
@@ -59,8 +57,6 @@ import qualified Network.Wai as Wai
 data RequestReader = RequestReader { _now :: UTCTime
                                    , _request :: Wai.Request
                                    }
-
-type ContentType = CI ByteString
 
 data ETag = Strong ByteString
           | Weak ByteString


### PR DESCRIPTION
Call out to mapAcceptMedia in c04 and use its logic to select the
correct media type to use.

Gets rid of the ContentType header and uses the MediaType one provided
by Network.HTTP.Media.
